### PR TITLE
Add Fondazione BEIC, video.beic.it

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -219,4 +219,14 @@
     },
     "targets": ["jitsi02.loclix.io:8081"]
   }
+  {
+    "labels": {
+      "job": "node",
+      "jitsi_url": "https://video.beic.it",
+      "jitsi_hosted_by": "Fondazione BEIC",
+      "jitsi_hosted_by_url": "https://www.beic.it",
+      "jitsi_hosted_by_kind": "INSTITUTION"
+    },
+    "targets": ["video.beic.it:8081"]
+  }
 ]


### PR DESCRIPTION
Al momento ha 8 core, 32 GB RAM, 1 Gb/s. Può crescere.